### PR TITLE
Filtering on Docker resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,21 @@ Command line Execution
     mvn mmik8:undeploy
     
     
-How to structure you project
+## How to structure you project
 
-    src/main/docker/Dockerfile
+### Docker files.
+
+You can add your Docker file, and any other text based files you want to use in a directory:
+
+    src/main/docker/
+
+The default directory is `src/main/docker/`, however you can define your own:
+
+    <configuration>
+        <dockerConfDir>myOwn/dir</dockerConfDir>
+    </configuration>
+
+### Kubernetes files
     
 The plugin looks for a kubernetes yml files in this structure
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-resources-plugin</artifactId>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
@@ -39,6 +39,11 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
         getLog().info(msg);
     }
     
+    protected void error(String msg,Throwable e){
+        getLog().error(msg,e);
+    }
+    
+    
     protected boolean dockerfileExist(String dockerDirectory){
         return processBuilderHelper.contains(dockerDirectory, DOCKERFILE);// TODO: Make configuratable ?, or loop through all Dockerfiles?
     }

--- a/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
@@ -1,6 +1,5 @@
 package com.mmiholdings.k8.plugin;
 
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
@@ -8,12 +7,8 @@ import java.io.File;
 
 /**
  * Abstract class for docker mojos. Define some shared parameters
- * @see https://maven.apache.org/guides/plugin/guide-java-plugin-development.html
  */
 public abstract class AbstractDockerMojo extends AbstractMojo {
-    
-    @Parameter(defaultValue = "${project.build.directory}", readonly = true, required=false)
-    protected File target;
     
     @Parameter( property = "imageName", defaultValue = "${project.artifactId}", readonly=true, required=false)
     protected String imageName;
@@ -30,22 +25,11 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     @Parameter( property = "artefactType", defaultValue = "${project.packaging}", readonly=true, required=false)
     protected String artefactType;
     
-    @Parameter( property = "encoding", defaultValue = "${project.build.sourceEncoding}" )
-    protected String encoding;
+    @Parameter( property = "dockerFileName", defaultValue = "Dockerfile", readonly=true, required=false)
+    protected String dockerFileName;
     
-    protected final ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
-        
-    protected void info(String msg){
-        getLog().info(msg);
-    }
-    
-    protected void error(String msg,Throwable e){
-        getLog().error(msg,e);
-    }
-    
-    
-    protected boolean dockerfileExist(String dockerDirectory){
-        return processBuilderHelper.contains(dockerDirectory, DOCKERFILE);// TODO: Make configuratable ?, or loop through all Dockerfiles?
+    protected boolean dockerfileExist(){
+        return processBuilderHelper.contains(dockerConfDir, dockerFileName);
     }
     
     protected String getFullyQualifiedImageName(){
@@ -58,7 +42,4 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     protected static final String BUILD = "build";
     protected static final String RMI = "rmi";
     protected static final String MINUS_T = "-t";
-    protected static final String MINUS_F = "-f";
-    protected static final String DOCKERFILE = "Dockerfile";
-    
 }

--- a/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/AbstractDockerMojo.java
@@ -30,6 +30,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     @Parameter( property = "artefactType", defaultValue = "${project.packaging}", readonly=true, required=false)
     protected String artefactType;
     
+    @Parameter( property = "encoding", defaultValue = "${project.build.sourceEncoding}" )
+    protected String encoding;
+    
     protected final ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
         
     protected void info(String msg){
@@ -46,8 +49,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     
     protected static final String DOT = ".";
     protected static final String DOUBLE_DOT = ":";
-    protected static final String COPY = "cp"; // TODO: Is this Linux specific ? What about poor Windoze users ?
-    protected static final String REMOVE = "rm"; // TODO: Is this Linux specific ? What about poor Windoze users ?
     protected static final String DOCKER = "docker";
     protected static final String BUILD = "build";
     protected static final String RMI = "rmi";

--- a/src/main/java/com/mmiholdings/k8/plugin/AbstractKubernetesMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/AbstractKubernetesMojo.java
@@ -1,0 +1,52 @@
+package com.mmiholdings.k8.plugin;
+
+import static com.mmiholdings.k8.plugin.AbstractMojo.MINUS_F;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Abstract class for kubernetes mojos. Define some shared parameters
+ * @see https://maven.apache.org/guides/plugin/guide-java-plugin-development.html
+ */
+public abstract class AbstractKubernetesMojo extends AbstractMojo {
+    
+    @Parameter( property = "kubernetesConfDir", defaultValue = "${project.basedir}/src/main/k8", readonly=true, required=false)
+    protected String kubernetesConfDir;
+    
+    @Parameter( property = "persistenceFileName", defaultValue = "persistence.yml", readonly=true, required=false)
+    protected String persistenceFileName;
+    
+    @Parameter( property = "claimFileName", defaultValue = "claim.yml", readonly=true, required=false)
+    protected String claimFileName;
+    
+    @Parameter( property = "deploymentFileName", defaultValue = "deployment.yml", readonly=true, required=false)
+    protected String deploymentFileName;
+    
+    @Parameter( property = "serviceFileName", defaultValue = "service.yml", readonly=true, required=false)
+    protected String serviceFileName;
+    
+    protected boolean kubernetesfileExist(String filename){
+        return processBuilderHelper.contains(kubernetesConfDir, filename);
+    }
+    
+    protected void runKubeControl(String instruction,String filename) throws MojoExecutionException {
+        if (kubernetesfileExist(filename)) {
+            List<String> command = new ArrayList<>();
+            command.add(KUBE_CONTROL);
+            command.add(instruction);
+            command.add(MINUS_F);
+            command.add(filename);
+            try {
+                processBuilderHelper.executeCommand(kubernetesConfDir, command);
+            } catch (IOException | InterruptedException e) {
+                throw new MojoExecutionException("Could not " + instruction + " from Kubernetes [" + filename + "]",e);
+            }
+        }
+    }
+    
+    protected static final String KUBE_CONTROL = "kubectl";
+    
+}

--- a/src/main/java/com/mmiholdings/k8/plugin/AbstractMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/AbstractMojo.java
@@ -1,0 +1,31 @@
+package com.mmiholdings.k8.plugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+
+/**
+ * Abstract class for our own mojos. Define some shared parameters
+ * @see https://maven.apache.org/guides/plugin/guide-java-plugin-development.html
+ */
+public abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
+    
+    @Parameter(defaultValue = "${project.build.directory}", readonly = true, required=false)
+    protected File target;
+    
+    @Parameter( property = "encoding", defaultValue = "${project.build.sourceEncoding}" )
+    protected String encoding;
+    
+    protected final ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
+        
+    protected void info(String msg){
+        getLog().info(msg);
+    }
+    
+    protected void error(String msg,Throwable e){
+        getLog().error(msg,e);
+    }
+    
+    protected static final String MINUS_F = "-f";
+}

--- a/src/main/java/com/mmiholdings/k8/plugin/BuildDockerImageMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/BuildDockerImageMojo.java
@@ -47,8 +47,8 @@ public class BuildDockerImageMojo extends AbstractDockerMojo {
         info("Including deployable unit [" + deployableUnit + "]");
         
         try {
-            if (dockerfileExist(dockerConfDir)) {
-                filterDockerfile();
+            if (dockerfileExist()) {
+                filterDockerfiles();
                 runDockerBuildCommand();
             }
         }  catch (IOException | InterruptedException ex) {
@@ -59,7 +59,7 @@ public class BuildDockerImageMojo extends AbstractDockerMojo {
     /*
     * Here copy the Dockerfile to target folder, and add filtering. So all pom vars will be substituted.
     */
-    private void filterDockerfile() throws MojoExecutionException{
+    private void filterDockerfiles() throws MojoExecutionException{
         try {
             MavenResourcesExecution mre = new MavenResourcesExecution(getResources(), new File(dockerConfDir), this.project, this.encoding, new ArrayList<>(), new ArrayList<>(), session);
             mavenResourcesFiltering.filterResources(mre);
@@ -82,11 +82,13 @@ public class BuildDockerImageMojo extends AbstractDockerMojo {
     private List<Resource> getResources(){
         List<Resource> resources = new ArrayList<>();
         // Add (by default) Dockerfile
-        resources.add(createResource(DOCKERFILE));
+        info("... including " + dockerFileName);
+        resources.add(createResource(dockerFileName));
         
         // Add any other as defined by the user
         if(dockerImageResources!=null && !dockerImageResources.isEmpty()){
             dockerImageResources.forEach((userDefinedResource) -> {
+                info("... including " + userDefinedResource);
                 resources.add(createResource(userDefinedResource));
             });
         }

--- a/src/main/java/com/mmiholdings/k8/plugin/BuildDockerImageMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/BuildDockerImageMojo.java
@@ -8,7 +8,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenResourcesExecution;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 
 /**
  * Maven Plug-in to build the docker image.
@@ -19,6 +26,18 @@ public class BuildDockerImageMojo extends AbstractDockerMojo {
     
     private String deployableUnit;
     
+    @Parameter(defaultValue="${project}",required=true, readonly=true)
+    protected MavenProject project;
+    
+    @Parameter( defaultValue = "${session}", required = true, readonly = true )
+    protected MavenSession session;
+    
+    @Component( role=MavenResourcesFiltering.class, hint="default")
+    protected MavenResourcesFiltering mavenResourcesFiltering;
+
+    @Parameter
+    private List<String> dockerImageResources;
+    
     @Override
     public void execute() throws MojoExecutionException {
         info("Building Image using Dockerfile in [" + dockerConfDir + "]");
@@ -27,44 +46,60 @@ public class BuildDockerImageMojo extends AbstractDockerMojo {
         this.deployableUnit = f.getAbsolutePath();
         info("Including deployable unit [" + deployableUnit + "]");
         
-        execute(dockerConfDir, getFullyQualifiedImageName());
-    }
-
-    private void execute(String dockerDirectory, String imageName) {
         try {
-            if (dockerfileExist(dockerDirectory)) {
-                runCopyArtefactCommand(dockerDirectory);
-                runDockerBuildCommand(dockerDirectory, imageName);
-                runRemoveArtefactCommand(dockerDirectory);
+            if (dockerfileExist(dockerConfDir)) {
+                filterDockerfile();
+                runDockerBuildCommand();
             }
-        }  catch (IOException | InterruptedException e) {
-            getLog().error(e);
+        }  catch (IOException | InterruptedException ex) {
+            throw new MojoExecutionException(ex.getMessage(),ex);
         }
     }
 
-    private void runCopyArtefactCommand(String dockerDirectory) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<>();
-        command.add(COPY);
-        command.add(deployableUnit);
-        command.add(DOT);
-        processBuilderHelper.executeCommand(dockerDirectory, command);
+    /*
+    * Here copy the Dockerfile to target folder, and add filtering. So all pom vars will be substituted.
+    */
+    private void filterDockerfile() throws MojoExecutionException{
+        try {
+            MavenResourcesExecution mre = new MavenResourcesExecution(getResources(), new File(dockerConfDir), this.project, this.encoding, new ArrayList<>(), new ArrayList<>(), session);
+            mavenResourcesFiltering.filterResources(mre);
+        } catch (MavenFilteringException ex) {
+            throw new MojoExecutionException(ex.getMessage(),ex);
+        }
     }
-
-    private void runRemoveArtefactCommand(String dockerDirectory) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<>();
-        command.add(REMOVE);
-        command.add(artefactName + DOT + artefactType);
-        processBuilderHelper.executeCommand(dockerDirectory, command);
-    }
-
-    private void runDockerBuildCommand(String dockerDirectory, String imageName) throws InterruptedException, IOException {
+    
+    private void runDockerBuildCommand() throws InterruptedException, IOException {
         List<String> command = new ArrayList<>();
         command.add(DOCKER);
         command.add(BUILD);
         command.add(MINUS_T);
-        command.add(imageName);
+        command.add(getFullyQualifiedImageName());
         info("Executing [docker build -t " + imageName + "]");
         command.add(DOT);
-        processBuilderHelper.executeCommand(dockerDirectory, command);
+        processBuilderHelper.executeCommand(target.getAbsolutePath(), command);
+    }
+    
+    private List<Resource> getResources(){
+        List<Resource> resources = new ArrayList<>();
+        // Add (by default) Dockerfile
+        resources.add(createResource(DOCKERFILE));
+        
+        // Add any other as defined by the user
+        if(dockerImageResources!=null && !dockerImageResources.isEmpty()){
+            dockerImageResources.forEach((userDefinedResource) -> {
+                resources.add(createResource(userDefinedResource));
+            });
+        }
+        
+        return resources;
+    }
+    
+    private Resource createResource(String name){ 
+        Resource resource = new Resource();
+        resource.addInclude(name);
+        resource.setDirectory(dockerConfDir);
+        resource.setTargetPath(target.getAbsolutePath());
+        resource.setFiltering(true);
+        return resource;
     }
 }

--- a/src/main/java/com/mmiholdings/k8/plugin/DeleteDockerImageMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/DeleteDockerImageMojo.java
@@ -16,27 +16,20 @@ public class DeleteDockerImageMojo extends AbstractDockerMojo {
     
     @Override
     public void execute()throws MojoExecutionException {
-        info("Deleting Image [" + getFullyQualifiedImageName() +"]");
-        execute(dockerConfDir, getFullyQualifiedImageName());
-    }
-
-    private void execute(String dockerDirectory, String imageName) {
+        info("Deleting docker image [" + getFullyQualifiedImageName() +"]");
+        
         try {
-            if (dockerfileExist(dockerDirectory)) {
-                runDockerBuildCommand(dockerDirectory, imageName);
+            if (dockerfileExist(dockerConfDir)) {
+                List<String> command = new ArrayList<>();
+                command.add(DOCKER);
+                command.add(RMI);
+                command.add(MINUS_F);
+                command.add(getFullyQualifiedImageName());
+                processBuilderHelper.executeCommand(dockerConfDir, command);
             }
         }  catch (IOException | InterruptedException e) {
-            getLog().error(e);
+            error("Could not delete docker image [" + getFullyQualifiedImageName() + "]",e);
         }
-    }
-
-    private void runDockerBuildCommand(String dockerDirectory, String imageName) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<>();
-        command.add(DOCKER);
-        command.add(RMI);
-        command.add(MINUS_F);
-        command.add(imageName);
-        processBuilderHelper.executeCommand(dockerDirectory, command);
     }
 
 }

--- a/src/main/java/com/mmiholdings/k8/plugin/DeleteDockerImageMojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/DeleteDockerImageMojo.java
@@ -19,7 +19,7 @@ public class DeleteDockerImageMojo extends AbstractDockerMojo {
         info("Deleting docker image [" + getFullyQualifiedImageName() +"]");
         
         try {
-            if (dockerfileExist(dockerConfDir)) {
+            if (dockerfileExist()) {
                 List<String> command = new ArrayList<>();
                 command.add(DOCKER);
                 command.add(RMI);

--- a/src/main/java/com/mmiholdings/k8/plugin/DeployK8Mojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/DeployK8Mojo.java
@@ -1,61 +1,34 @@
 package com.mmiholdings.k8.plugin;
 
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.*;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 @Mojo(name = "deploy")
-public class DeployK8Mojo extends AbstractMojo {
-
-    public static final String PERSISTENCE_YML  = "persistence.yml";
-    public static final String CLAIM_YML        = "claim.yml";
-    public static final String DEPLOYMENT_YML   = "deployment.yml";
-    public static final String SERVICE_YML      = "service.yml";
-
-    ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
+public class DeployK8Mojo extends AbstractKubernetesMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
         
-        getLog().info("Deploying component");
-        try {
-            File configDir = new File("/config");
-            if (configDir.exists() && configDir.isDirectory()) {
+        info("Deploying kubernetes components ....");
+        
+        File configDir = new File("/config");
+        if (configDir.exists() && configDir.isDirectory()) {
+            try {
                 createConfig(configDir);
-            }
-
-            String s = Paths.get(".").toAbsolutePath().normalize().toString();
-            String k8Directory = s + "/src/main/k8/";
-            execute(k8Directory, PERSISTENCE_YML);
-            execute(k8Directory, CLAIM_YML);
-            execute(k8Directory, DEPLOYMENT_YML);
-            execute(k8Directory, SERVICE_YML);
-        } catch (InterruptedException | IOException e) {
-            throw new MojoExecutionException("Could not deploy to Kubernetes",e);
+            } catch (InterruptedException | IOException e) {
+                throw new MojoExecutionException("Could not create config map for Kubernetes",e);
+            } 
         }
-    }
 
-    private void execute(String k8Directory, String command) throws InterruptedException, IOException {
-        if (processBuilderHelper.contains(k8Directory, command)) {
-            runCommand(command, k8Directory);
-        }
-    }
-
-
-
-    private void runCommand(String cmd, String k8Directory) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<>();
-        command.add("kubectl");
-        command.add("create");
-        command.add("-f");
-        command.add(cmd);
-        processBuilderHelper.executeCommand(k8Directory, command);
+        runKubeControl(CREATE,persistenceFileName);
+        runKubeControl(CREATE,claimFileName);
+        runKubeControl(CREATE,deploymentFileName);
+        runKubeControl(CREATE,serviceFileName);  
     }
 
     private void createConfig(File folder) throws InterruptedException, IOException {
@@ -64,7 +37,7 @@ public class DeployK8Mojo extends AbstractMojo {
             if (listOfFiles[i].isFile()) {
                 List<String> cmd = configMapCommand(listOfFiles[i].getName());
                 String str = Arrays.toString(cmd.toArray());
-                getLog().info("config map command " + str);
+                info("config map command " + str);
             }
         }
     }
@@ -72,11 +45,17 @@ public class DeployK8Mojo extends AbstractMojo {
 
     private List<String> configMapCommand(String fileName) {
         List<String> command = new ArrayList<>();
-        command.add("kubectl");
-        command.add("create");
-        command.add("configmap");
-        command.add("fileName");
+        command.add(KUBE_CONTROL);
+        command.add(CREATE);
+        command.add(CONFIG_MAP);
+        command.add(FILENAME);
         command.add("--from-file=../../../config/" + fileName);
         return command;
     }
+    
+    
+    private static final String CREATE = "create";
+    private static final String CONFIG_MAP = "configmap";
+    private static final String FILENAME = "fileName";
+        
 }

--- a/src/main/java/com/mmiholdings/k8/plugin/DeployK8Mojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/DeployK8Mojo.java
@@ -20,44 +20,37 @@ public class DeployK8Mojo extends AbstractMojo {
 
     ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
 
-    public void execute()
-            throws MojoExecutionException
-    {
+    @Override
+    public void execute() throws MojoExecutionException {
+        
         getLog().info("Deploying component");
-
-        File configDir = new File("/config");
-        if (configDir.exists() && configDir.isDirectory()) {
-            try {
+        try {
+            File configDir = new File("/config");
+            if (configDir.exists() && configDir.isDirectory()) {
                 createConfig(configDir);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            } catch (IOException e) {
-                e.printStackTrace();
             }
-        }
 
-        String s = Paths.get(".").toAbsolutePath().normalize().toString();
-        String k8Directory = s + "/src/main/k8/";
-        execute(k8Directory, PERSISTENCE_YML);
-        execute(k8Directory, CLAIM_YML);
-        execute(k8Directory, DEPLOYMENT_YML);
-        execute(k8Directory, SERVICE_YML);
+            String s = Paths.get(".").toAbsolutePath().normalize().toString();
+            String k8Directory = s + "/src/main/k8/";
+            execute(k8Directory, PERSISTENCE_YML);
+            execute(k8Directory, CLAIM_YML);
+            execute(k8Directory, DEPLOYMENT_YML);
+            execute(k8Directory, SERVICE_YML);
+        } catch (InterruptedException | IOException e) {
+            throw new MojoExecutionException("Could not deploy to Kubernetes",e);
+        }
     }
 
-    private void execute(String k8Directory, String command) {
-        try {
-            if (processBuilderHelper.contains(k8Directory, command)) {
-                runCommand(command, k8Directory);
-            }
-        }  catch (Exception e) {
-            getLog().error(e);
+    private void execute(String k8Directory, String command) throws InterruptedException, IOException {
+        if (processBuilderHelper.contains(k8Directory, command)) {
+            runCommand(command, k8Directory);
         }
     }
 
 
 
     private void runCommand(String cmd, String k8Directory) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add("kubectl");
         command.add("create");
         command.add("-f");
@@ -78,7 +71,7 @@ public class DeployK8Mojo extends AbstractMojo {
 
 
     private List<String> configMapCommand(String fileName) {
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add("kubectl");
         command.add("create");
         command.add("configmap");

--- a/src/main/java/com/mmiholdings/k8/plugin/UnDeployK8Mojo.java
+++ b/src/main/java/com/mmiholdings/k8/plugin/UnDeployK8Mojo.java
@@ -1,54 +1,22 @@
 package com.mmiholdings.k8.plugin;
 
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
-import java.io.*;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-
 @Mojo(name = "undeploy")
-public class UnDeployK8Mojo extends AbstractMojo {
-
-    public static final String PERSISTENCE_YML  = "persistence.yml";
-    public static final String CLAIM_YML        = "claim.yml";
-    public static final String DEPLOYMENT_YML   = "deployment.yml";
-    public static final String SERVICE_YML      = "service.yml";
-
-    private final ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(getLog());
+public class UnDeployK8Mojo extends AbstractKubernetesMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        getLog().info("un Deploying component");
-        String s = Paths.get(".").toAbsolutePath().normalize().toString();
-        String dockerDirectory = s + "/src/main/k8/";
-
-        execute(dockerDirectory, SERVICE_YML);
-        execute(dockerDirectory, DEPLOYMENT_YML);
-        execute(dockerDirectory, CLAIM_YML);
-        execute(dockerDirectory, PERSISTENCE_YML);
+        info("Undeploying kubernetes components ....");
+        
+        runKubeControl(DELETE,serviceFileName);
+        runKubeControl(DELETE,deploymentFileName);
+        runKubeControl(DELETE,claimFileName);
+        runKubeControl(DELETE,persistenceFileName);
+        
     }
-
-    private void execute(String dockerDirectory, String command) {
-        try {
-            if (processBuilderHelper.contains(dockerDirectory, command)) {
-                runCommand(command, dockerDirectory);
-            }
-        }  catch (IOException | InterruptedException e) {
-            getLog().error(e);
-        }
-    }
-
-    private void runCommand(String cmd, String dockerDirectory) throws InterruptedException, IOException {
-        List<String> command = new ArrayList<>();
-        command.add("kubectl");
-        command.add("delete");
-        command.add("-f");
-        command.add(cmd);
-        processBuilderHelper.executeCommand(dockerDirectory, command);
-    }
-
-
+    
+    private static final String DELETE = "delete";
+    
 }


### PR DESCRIPTION
Rather than coping the war/jar to the Docker dir, copy (with filtering) the Dockerfile, and any other files the user want to ${target} directory. Also then include filtering, so we can use pom vars in the docker resources.